### PR TITLE
Replace Spark with Pyarrow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "train.py",
             "console": "integratedTerminal",
-            "args": "-c /workspace/config/config.dev.ini -f /data/pdb_seqres.txt"
+            "args": "-c /workspace/config/config.dev.ini -f /data/pdb_seqres.txt -d /db/pdb_data"
         },
         {
             "name": "Process PDB",
@@ -18,7 +18,7 @@
             "request": "launch",
             "program": "process_pdb.py",
             "console": "integratedTerminal",
-            "args": "-m /data/pdb/ -s /db/"
+            "args": "-m /data/pdb/ -o /db/pdb_data.arrow"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ docker run -it --rm data_processing pytest tests/data_processing
 ### Training
 Process downloaded PDB files using Spark
 ```bash
-docker-compose run --rm data_processing python process_pdb.py -m /data/pdb/ -s /db/
+docker-compose run --rm data_processing python process_pdb.py -m /data/pdb/ -o /db/pdb_data.arrow
 ```

--- a/docker/Dockerfile.process
+++ b/docker/Dockerfile.process
@@ -1,25 +1,4 @@
-FROM spark:3.5.1-scala2.12-java17-ubuntu
-
-USER root
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
-        git \
-        wget \
-    && apt-get clean \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /opt/miniconda3 \
-    && wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh \
-    && bash /tmp/miniconda.sh -b -u -p /opt/miniconda3 \
-    && rm -rf /tmp/miniconda.sh
-
-ENV PATH="/opt/miniconda3/bin:${PATH}"
-
-RUN conda install -y -c conda-forge \
-        python=3.12 \
-        pip \
-    && conda clean -afy
+FROM python:3.12
 
 COPY requirements/requirements.process.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir --default-timeout=1500 -r /tmp/requirements.txt \

--- a/nanofold/common/chain.py
+++ b/nanofold/common/chain.py
@@ -2,10 +2,9 @@ from nanofold.common.residue_definitions import RESIDUE_LOOKUP_3L
 
 
 class Chain:
-    def __init__(self, id, release_date, chain, rotations, translations, sequence, positions):
+    def __init__(self, id, release_date, rotations, translations, sequence, positions):
         self.id = id
         self.release_date = release_date
-        self.chain = chain
         self.rotations = rotations
         self.translations = translations
         self.sequence = sequence
@@ -13,23 +12,21 @@ class Chain:
 
     @classmethod
     def from_residue_list(cls, id, release_date, residue_list, rotations, translations):
-        chain = [{"resname": r["resname"], "id": r["id"]} for r in residue_list]
         sequence = "".join([RESIDUE_LOOKUP_3L[r["resname"]] for r in residue_list])
         positions = [r["id"][-1][1] for r in residue_list]
-        return cls(id, release_date, chain, rotations, translations, sequence, positions)
+        return cls(id, release_date, rotations, translations, sequence, positions)
 
     def __repr__(self):
         return f"Chain(id={self.id}, release={self.release_date}, sequence={self.sequence})"
 
     def __len__(self):
-        return len(self.chain)
+        return len(self.sequence)
 
     def __getitem__(self, key):
         if isinstance(key, slice):
             return Chain(
                 self.id,
                 self.release_date,
-                self.chain[key],
                 self.rotations[key],
                 self.translations[key],
                 self.sequence[key],
@@ -42,7 +39,6 @@ class Chain:
             "model_id": chain.id[0],
             "chain_id": chain.id[1],
             "release_date": chain.release_date,
-            "chain": chain.chain,
             "rotations": chain.rotations.flatten().tolist(),
             "translations": chain.translations.flatten().tolist(),
             "sequence": chain.sequence,

--- a/nanofold/data_processing/mmcif.py
+++ b/nanofold/data_processing/mmcif.py
@@ -6,7 +6,7 @@ from Bio.PDB import MMCIFParser
 
 from nanofold.common.residue_definitions import BACKBONE_ATOMS
 from nanofold.common.residue_definitions import RESIDUE_LOOKUP_3L
-from nanofold.data_processing.chain import Chain
+from nanofold.common.chain import Chain
 from nanofold.data_processing.residue import compute_residue_frames
 
 
@@ -36,7 +36,7 @@ def get_longest_match(chain, sequence):
 
 def parse_chains(model):
     result = []
-    release_date = min(model.mmcif_dict.get("_pdbx_audit_revision_history.revision_date", [None]))
+    release_date = min(model.mmcif_dict["_pdbx_audit_revision_history.revision_date"])
     for strand_id, sequence in zip(
         model.mmcif_dict.get("_entity_poly.pdbx_strand_id", []),
         model.mmcif_dict.get("_entity_poly.pdbx_seq_one_letter_code", []),

--- a/process_pdb.py
+++ b/process_pdb.py
@@ -1,12 +1,12 @@
 import argparse
-import csv
+import pyarrow as pa
 import logging
 from Bio.PDB.PDBExceptions import PDBConstructionException
+from concurrent.futures import ProcessPoolExecutor
 from itertools import batched
 from pathlib import Path
-from pyspark.sql import SparkSession
 
-from nanofold.data_processing.chain import Chain
+from nanofold.common.chain import Chain
 from nanofold.data_processing.mmcif import list_available_mmcif
 from nanofold.data_processing.mmcif import load_model
 from nanofold.data_processing.mmcif import parse_chains
@@ -15,10 +15,10 @@ from nanofold.data_processing.mmcif import parse_chains
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-b", "--batch", help="Batch size of files to process", default=500, type=int
+        "-b", "--batch", help="Batch size of files to process", default=1000, type=int
     )
     parser.add_argument("-m", "--mmcif", help="Directory containing mmcif files", type=Path)
-    parser.add_argument("-s", "--store", help="Directory to store processed data in", type=Path)
+    parser.add_argument("-o", "--output", help="Output Arrow IPC file", type=Path)
     parser.add_argument("-l", "--logging", help="Logging level", default="INFO")
     return parser.parse_args()
 
@@ -29,8 +29,7 @@ def process_pdb_file(filepath):
     except PDBConstructionException as e:
         logging.warn(f"Got PDB construction error for file={filepath}, error={e}")
         return []
-    chains = parse_chains(model)
-    return [Chain.to_record(c) for c in chains]
+    return parse_chains(model)
 
 
 def get_id(filepath):
@@ -40,34 +39,18 @@ def get_id(filepath):
 def main():
     args = parse_args()
     logging.basicConfig(level=getattr(logging, args.logging.upper()))
-    id_filepath = args.store / "processed_ids.csv"
-    parquet_directory = args.store / "pdb_data"
-    spark = SparkSession.builder.appName("PDB Data Processing").getOrCreate()
-
-    try:
-        with open(id_filepath) as f:
-            reader = csv.reader(f)
-            processed_ids = list(reader)[0]
-    except FileNotFoundError:
-        processed_ids = []
 
     pdb_files = list_available_mmcif(args.mmcif)
-    pdb_files = list(filter(lambda x: get_id(x) not in processed_ids, pdb_files))
     logging.info(f"Found {len(pdb_files)} files to process")
 
-    for i, batch in enumerate(batched(pdb_files, args.batch)):
-        pdb_files_rdd = spark.sparkContext.parallelize(batch)
-        data = pdb_files_rdd.flatMap(process_pdb_file)
-
-        if not data.isEmpty():
-            df = spark.createDataFrame(data)
-            df.write.mode("append").parquet(str(parquet_directory))
-
-        processed_ids += [get_id(f) for f in batch]
-        with open(id_filepath, mode="w") as f:
-            writer = csv.writer(f)
-            writer.writerow(processed_ids)
-        logging.info(f"Processed {i * args.batch + len(batch)}/{len(pdb_files)} files")
+    with ProcessPoolExecutor() as executor:
+        with pa.OSFile(str(args.output), mode="w") as f:
+            with pa.ipc.new_file(f, Chain.SCHEMA) as writer:
+                for i, batch in enumerate(batched(pdb_files, args.batch)):
+                    result = [c for chains in executor.map(process_pdb_file, batch) for c in chains]
+                    writer.write_batch(Chain.to_record_batch(result))
+                    logging.info(f"Processed {i * args.batch + len(batch)}/{len(pdb_files)} files")
+    logging.info(f"Finished processing {len(pdb_files)} files, output written to {args.output}")
 
 
 if __name__ == "__main__":

--- a/requirements/requirements.process.txt
+++ b/requirements/requirements.process.txt
@@ -1,4 +1,4 @@
 biopython
 numpy
-pyspark
+polars
 pytest

--- a/requirements/requirements.process.txt
+++ b/requirements/requirements.process.txt
@@ -1,4 +1,4 @@
 biopython
 numpy
-polars
+pyarrow
 pytest

--- a/requirements/requirements.train.txt
+++ b/requirements/requirements.train.txt
@@ -3,5 +3,5 @@ pytest
 torch
 torchinfo
 mlflow
-pyspark
+pyarrow
 --extra-index-url https://download.pytorch.org/whl/cu121


### PR DESCRIPTION
Replaces Spark to use Pyarrow instead. Spark brought a lot of overhead and this approach uses Python's simple ProcessPoolExecutor interface. Also changed the usage of parquet to Pyarrow instead, so I can take advantage of Arrow's memory mapped zero copy tables as the underlying data for Pytorch training