### PR TITLE
Improvements to the download_pdb script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Download and unzip `mmCIF` files that were deposited before the cut off date wit
 export DATA_DIR=~/data
 export CUTOFF_DATE=1989-01-01
 mkdir -p $DATA_DIR/pdb && ./scripts/download_pdb.sh $DATA_DIR/pdb $CUTOFF_DATE
-gzip -d $DATA_DIR/pdb/*.cif.gz
 ```
 
 Download and unzip small BFD (17GB) with


### PR DESCRIPTION
Mostly standard stuff to clean up the bash script with suggestions from shellcheck. 

Added some more logging in case folks didn't have certain programs installed.

(Some opinionated decision was to move the gzip command into the script itself.)