### PR TITLE
Add DATA_DIR path environment var to BFD download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mkdir -p $DATA_DIR/pdb && ./scripts/download_pdb.sh $DATA_DIR/pdb $CUTOFF_DATE
 Download and unzip small BFD (17GB) with
 ```bash
 wget https://storage.googleapis.com/alphafold-databases/reduced_dbs/bfd-first_non_consensus_sequences.fasta.gz -P $DATA_DIR
-gzip -d bfd-first_non_consensus_sequences.fasta.gz
+gzip -d $DATA_DIR/bfd-first_non_consensus_sequences.fasta.gz
 ```
 
 Download and unzip Uniclust30 with


### PR DESCRIPTION
The download command for BFD file was missing $DATA_DIR in the main `README.md`.  Changed:

```
gzip -d bfd-first_non_consensus_sequences.fasta.gz
```

to

```
gzip -d $DATA_DIR/bfd-first_non_consensus_sequences.fasta.gz
```